### PR TITLE
Ensure request retrieval, fhir search, and  result submission all inc…

### DIFF
--- a/examples/ptmatchadapter-fril/src/main/java/org/mitre/ptmatchadapter/fril/RecordMatchRequestProcessor.java
+++ b/examples/ptmatchadapter-fril/src/main/java/org/mitre/ptmatchadapter/fril/RecordMatchRequestProcessor.java
@@ -58,6 +58,7 @@ import org.mitre.ptmatchadapter.format.SimplePatientCsvFormat;
 import org.mitre.ptmatchadapter.fril.config.Configuration;
 import org.mitre.ptmatchadapter.fril.config.Configuration.LeftDataSource.Preprocessing.Deduplication.MinusFile;
 import org.mitre.ptmatchadapter.model.ServerAuthorization;
+import org.mitre.ptmatchadapter.util.AuthorizationUtil;
 import org.mitre.ptmatchadapter.util.ParametersUtil;
 
 import org.slf4j.Logger;
@@ -371,7 +372,7 @@ public class RecordMatchRequestProcessor {
 
     LOG.info("retrieveAndStoreData, serverBase: {}", serverBase);
     
-    final ServerAuthorization serverAuthorization = findServerAuthorization(serverBase);
+    final ServerAuthorization serverAuthorization = AuthorizationUtil.findServerAuthorization(serverAuthorizations, serverBase);
     
     BearerTokenAuthInterceptor authInterceptor = null;
     if (serverAuthorization != null) {
@@ -412,21 +413,6 @@ public class RecordMatchRequestProcessor {
     return numRecords;
   }
 
-    
-  private ServerAuthorization findServerAuthorization(String serverBase) {
-    for (ServerAuthorization sa : serverAuthorizations) {
-      LOG.info("findServerAuth serverUrl: {}  {}", sa.getServerUrl(), serverBase);
-      try {
-        if (sa.getServerUrl().equals(serverBase)) {
-          return sa;
-        }
-      } catch (NullPointerException e) {
-        // should never happen
-        LOG.warn("NULL Server URL found for server authorization: {}", sa.getTitle());
-      }
-    }
-    return null;
-  }
     
   private String urlEncodeQueryParams(String url) {
     final StringBuilder sb = new StringBuilder((int) (url.length() * 1.2));

--- a/examples/ptmatchadapter-fril/src/main/resources/application.properties
+++ b/examples/ptmatchadapter-fril/src/main/resources/application.properties
@@ -29,13 +29,13 @@ oauth2.authorization.accessTokenEndpoint=/openid-connect-server-webapp/token
 
 # Id and secret created by the authorization server for the patient match adapter
 ptmatchadapter.oauth2.clientID=c726117d-8f31-4324-8aba-0e3793f857df
-ptmatchadapter.oauth2.clientSecret=AI1hpmx-ZQLIViRymN3y5_CWjRjuuxNdpOsk5jko463a_9YFANBNYGB2suRaTIp17pYqV0Sv08N2NL3G-KumITY
+ptmatchadapter.oauth2.clientSecret=AKhclut18vd2ZdIdjAPYRX6y2Ykw24KVNP0CceYYMUTlLScq0vkaiKrn-mffj7JFeCrSP5sTxDo3n4aeGwsXm-w
 
 ptmatchadapter.clientAuthRedirectPath=/mgr/authCodeResp
 
 # URL to the FHIR server from which to request messages. 
 # Include scheme, host name + port (when not 80 or 443) + root path (when applicable)
-src.fhir.server.base = http://localhost:8881
+src.fhir.server.base = http://localhost:3001
 
 ptmatchadapter.workDir = recordMatchJobs
 # Mustache template file w/ matching rules and data source locations

--- a/examples/ptmatchadapter-fril/src/main/resources/beans-config.xml
+++ b/examples/ptmatchadapter-fril/src/main/resources/beans-config.xml
@@ -76,6 +76,7 @@
 
   <bean id="resultSender" class="org.mitre.ptmatchadapter.ResultSender">
     <property name="client" ref="fhirRestClient" />
+    <property name="serverAuthorizations" ref="serverAuthorizations"/>
   </bean>
 
 

--- a/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/MessageRetriever.java
+++ b/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/MessageRetriever.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.hl7.fhir.instance.model.Bundle;
 import org.mitre.ptmatchadapter.model.ServerAuthorization;
+import org.mitre.ptmatchadapter.util.AuthorizationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,7 @@ public class MessageRetriever {
     Bundle results = null;
 
     final ServerAuthorization serverAuthorization =
-        findServerAuthorization(client.getServerBase());
+        AuthorizationUtil.findServerAuthorization(serverAuthorizations, client.getServerBase());
 
     BearerTokenAuthInterceptor authInterceptor = null;
     if (serverAuthorization != null) {
@@ -132,22 +133,6 @@ public class MessageRetriever {
     return results;
   }
 
-  private ServerAuthorization findServerAuthorization(String serverBase) {
-    if (serverAuthorizations != null) {
-      for (ServerAuthorization sa : serverAuthorizations) {
-        LOG.info("findServerAuth serverUrl: {}  {}", sa.getServerUrl(), serverBase);
-        try {
-          if (sa.getServerUrl().equals(serverBase)) {
-            return sa;
-          }
-        } catch (NullPointerException e) {
-          // should never happen
-          LOG.warn("NULL Server URL found for server authorization: {}", sa.getTitle());
-        }
-      }
-    }
-    return null;
-  }
   
   /**
    * @return the desinationUri

--- a/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/util/AuthorizationUtil.java
+++ b/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/util/AuthorizationUtil.java
@@ -1,0 +1,62 @@
+/**
+ * PtMatchAdapter - a patient matching system adapter
+ * Copyright (C) 2016 The MITRE Corporation.  ALl rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mitre.ptmatchadapter.util;
+
+import java.util.List;
+
+import org.mitre.ptmatchadapter.model.ServerAuthorization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Michael Los, mel@mitre.org
+ *
+ */
+public abstract class AuthorizationUtil {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(AuthorizationUtil.class);
+
+  public static final ServerAuthorization findServerAuthorization(
+      List<ServerAuthorization> serverAuthorizations, String serverBase) {
+    
+    String slashlessBaseUrl;
+    // Remove any trailing slash
+    if (serverBase != null && serverBase.endsWith("/")) {
+      slashlessBaseUrl = serverBase.substring(0, serverBase.length() - 1);
+    } else {
+      slashlessBaseUrl = serverBase;
+    }
+    
+    if (serverAuthorizations != null && slashlessBaseUrl != null) {
+      for (ServerAuthorization sa : serverAuthorizations) {
+        LOG.info("findServerAuth serverUrl: {}  {}", sa.getServerUrl(), slashlessBaseUrl);
+        try {
+          if (sa.getServerUrl().equals(slashlessBaseUrl)) {
+            return sa;
+          }
+        } catch (NullPointerException e) {
+          // should never happen
+          LOG.warn("NULL Server URL found for server authorization: {}",
+              sa.getTitle());
+        }
+      }
+    }
+    return null;
+  }
+
+}


### PR DESCRIPTION
…lude bearer token
- Add bearer token to http call that sends record match results to fhir message broker
- Ensure server base url has no trailing slash (fixes issue where bearer token not sent during fhir search request)
- Add abstract class, AuthorizationUtil, to hold findServerAuthorization() method used in 3 places
