### PR TITLE
Update HAPI FHIR Client (to v1.5) and other java jar dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+and this project adheres to [Semantic Versioning 2.0.0 ](http://semver.org/).
+
+## [Unreleased]
+### Added
+- CHANGELOG.md
+
+### Changed
+- jar dependencies at top level
+  - springVersion: from 4.2.4.RELEASE to 4.3.+.RELEASE 
+  - camelVersion: from 2.16.2 to 2.16.2+
+  - hapiFhirVersion: from 1.4 to 1.5
+  - slf4jVersion: from 1.7.18 to 1.7.18+
+  - junitVersion: from 4.12 to 4.12+
+- jar dependencies in examples/ptmatchadapter-fril
+  -  'xerces:xercesImpl:2.11.0' to 'xerces:xercesImpl:2.11.+'
+  -  'log4j:log4j:1.2.17' to 'log4j:log4j:1.2.17+'
+- jar dependencies in ptmatchadapter-common
+  -  'ch.qos.logback:logback-classic:1.1.5' to ch.qos.logback:logback-classic:1.1.5+'
+
+## 0.0.1-SNAPSHOT
+Initial version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # ptmatchadapter
 Adapter for patient matching systems to integrate with the [PCOR patient matching test harness](http://mitre.github.io/test-harness-interface/)
 
+## Building
+This project uses gradle for build management.  After changing the working directory to the project root, the following are useful commands.
+
+Compile and run unit tests for the project
+```
+$ gradle build
+```
+
+Present a list of available tasks
+```
+$ gradle tasks 
+```
+
+Present a list of gradle command-line options 
+```
+$ gradle --help 
+```
+
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,12 @@ subprojects {
   
   // gradle "extra" variables propagate to subprojects like a global variable
   ext {
-    springVersion = '4.2.4.RELEASE'
-    camelVersion = '2.16.2'
-    hapiFhirVersion = '1.4'
+    springVersion = '4.3.+.RELEASE'
+    camelVersion = '2.16.2+'
+    hapiFhirVersion = '1.5'
     mongodbVersion = '3.2.1'
-    slf4jVersion = '1.7.18'
-    junitVersion = '4.12'
+    slf4jVersion = '1.7.18+'
+    junitVersion = '4.12+'
   }
   
   task allDeps(type: DependencyReportTask){}

--- a/examples/ptmatchadapter-fril/README.md
+++ b/examples/ptmatchadapter-fril/README.md
@@ -6,6 +6,9 @@ for an adapter between the ptmatch test harness and a record matching system.
 
 To run, set the working directory to the project top level (i.., ptmatchadapter)
 
+## Configuring the Application
+Set properties in the file src/main/resources/applications.properties
+
 
 ## Running the Application
 
@@ -14,8 +17,10 @@ To run, set the working directory to the project top level (i.., ptmatchadapter)
 2. Change your working directory to the project's top level folder (i.e., ptmatchadapter).
 3. Enter the following one line line and press the Enter key: 
    
-gradlew :examples:ptmatchadapter-fril:bootRun 
-   
+./gradlew :examples:ptmatchadapter-fril:bootRun 
+
+After starting, the application will open a browser window within which you can specify an OpenID Connect server with which to associate the ptmatch adapter. 
+
 
 ## Stopping the Application
 

--- a/examples/ptmatchadapter-fril/build.gradle
+++ b/examples/ptmatchadapter-fril/build.gradle
@@ -86,7 +86,7 @@ dependencies {
   runtime files('lib/rsyntaxtextarea.jar')
 
   runtime 'commons-logging:commons-logging:1.2'
-  runtime 'log4j:log4j:1.2.17'
+  runtime 'log4j:log4j:1.2.17+'
 
   runtime 'au.com.bytecode:opencsv:2.4'
 
@@ -102,7 +102,7 @@ dependencies {
 
   // Something used by FRIL depends on xml-apis v1.4.x
   runtime 'xml-apis:xml-apis:1.4.01'
-  runtime 'xerces:xercesImpl:2.11.0'
+  runtime 'xerces:xercesImpl:2.11.+'
 }
 
 

--- a/examples/ptmatchadapter-fril/src/main/java/org/mitre/ptmatchadapter/fril/RecordMatchRequestProcessor.java
+++ b/examples/ptmatchadapter-fril/src/main/java/org/mitre/ptmatchadapter/fril/RecordMatchRequestProcessor.java
@@ -381,11 +381,9 @@ public class RecordMatchRequestProcessor {
       fhirRestClient.registerInterceptor(authInterceptor);
     }
     try {
-      IQuery<Bundle> query = fhirRestClient.search().byUrl(url)
-          .returnBundle(Bundle.class);
-  
       // Perform a search
-      final Bundle searchResults = query.execute();
+      final Bundle searchResults = fhirRestClient.search().byUrl(url)
+          .returnBundle(Bundle.class).execute();
   
       // Split the bundle into its component resources
       final SearchResultSplitter resultSplitter = new SearchResultSplitter();

--- a/examples/ptmatchadapter-fril/src/main/resources/application.properties
+++ b/examples/ptmatchadapter-fril/src/main/resources/application.properties
@@ -15,7 +15,7 @@ camel.springboot.jmxEnabled = true
 jmx.jolokiaPort = 8778
 
 
-# Use localhost to restrict requests to orginate from local system
+# Use localhost to restrict web GUI requests to originate from local system
 # use 0.0.0.0 to accept connections from any host
 ptmatchadapter.web.ipaddress=0.0.0.0
 ptmatchadapter.web.port=8082
@@ -28,8 +28,9 @@ oauth2.authorization.authCodeEndpoint=/openid-connect-server-webapp/authorize
 oauth2.authorization.accessTokenEndpoint=/openid-connect-server-webapp/token
 
 # Id and secret created by the authorization server for the patient match adapter
-ptmatchadapter.oauth2.clientID=c726117d-8f31-4324-8aba-0e3793f857df
-ptmatchadapter.oauth2.clientSecret=AKhclut18vd2ZdIdjAPYRX6y2Ykw24KVNP0CceYYMUTlLScq0vkaiKrn-mffj7JFeCrSP5sTxDo3n4aeGwsXm-w
+ptmatchadapter.oauth2.clientID=4d20025f-c4d2-4685-8489-0fba3ebfa82f
+ptmatchadapter.oauth2.clientSecret=E9io0OpRZCya9tZAYtIl-kwuWlbyg6orLzBK9XGd1LdLzZ7VlHCwR-rNlNiMxu934nI76OwXWuoOsJqH8ygWUA
+
 
 ptmatchadapter.clientAuthRedirectPath=/mgr/authCodeResp
 

--- a/ptmatchadapter-common/build.gradle
+++ b/ptmatchadapter-common/build.gradle
@@ -17,6 +17,6 @@ dependencies {
   compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.4'
   
   testCompile "junit:junit:${junitVersion}"
-  runtime 'ch.qos.logback:logback-classic:1.1.5'
+  runtime 'ch.qos.logback:logback-classic:1.1.5+'
 }
 

--- a/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/MessageRetriever.java
+++ b/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/MessageRetriever.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import ca.uhn.fhir.rest.client.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
-import ca.uhn.fhir.rest.gclient.IQuery;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 
 /**
@@ -99,7 +98,7 @@ public class MessageRetriever {
       sb.append("&_lastUpdated=gt");
       sb.append(df.format(d));
 
-      final IQuery<Bundle> query = client.search()
+      results = client.search()
           .byUrl(sb.toString())
           // .forResource(Bundle.class)
           // .encodedJson() // results in _format query parameter, which is not
@@ -110,10 +109,8 @@ public class MessageRetriever {
           // StringClientParam(Bundle.SP_TYPE)).matches().value(BundleTypeEnum.MESSAGE.toString()))
           // .and(Patient.CAREPROVIDER.hasChainedProperty(Organization.NAME.matches().value(destinationUri)))
           // .and(Patient.CAREPROVIDER.hasChainedProperty(Organization.NAME.matches().value("Health")))
-          .returnBundle(Bundle.class);
-
-      // Perform a search
-      results = query.execute();
+          .returnBundle(Bundle.class)
+          .execute();
 
     } catch (BaseServerResponseException e) {
       LOG.warn(String.format("Error response from server.  code: %d, %s",

--- a/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/NoOpRecordMatchRequestProcessor.java
+++ b/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/NoOpRecordMatchRequestProcessor.java
@@ -123,20 +123,15 @@ public class NoOpRecordMatchRequestProcessor {
         }
         try {
           // Retrieve the data associated with the search urls
-          IQuery<Bundle> query = fhirRestClient.search()
-              .byUrl(masterSearchUrl).returnBundle(Bundle.class);
-
-          // Perform a search
-          final Bundle masterSetResults = query.execute();
+          final Bundle masterSetResults = fhirRestClient.search()
+              .byUrl(masterSearchUrl).returnBundle(Bundle.class).execute();
 
           Bundle querySetResults = null;
           if (querySearchUrl != null) {
             // Retrieve the data associated with the search urls
-            query = fhirRestClient.search()
-                .byUrl(querySearchUrl).returnBundle(Bundle.class);
-
-            // Perform a search
-            querySetResults = query.execute();
+            querySetResults = fhirRestClient.search()
+                .byUrl(querySearchUrl).returnBundle(Bundle.class)
+                .execute();
           }
 
         } catch (BaseServerResponseException e) {

--- a/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/ResourceRetriever.java
+++ b/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/ResourceRetriever.java
@@ -57,13 +57,12 @@ public class ResourceRetriever {
       final StringBuilder sb = new StringBuilder(100);
       sb.append(queryExpr);
 
-      final IQuery<Bundle> query = client.search()
+      // Perform a search
+      results = client.search()
           .byUrl(sb.toString())
           .usingStyle(SearchStyleEnum.POST)  // POST ignored when byUrl is called
-          .returnBundle(Bundle.class);
-
-      // Perform a search
-      results = query.execute();
+          .returnBundle(Bundle.class)
+          .execute();
 
     } catch (BaseServerResponseException e) {
       LOG.warn(String.format("Error response from server.  code: %d, %s", e.getStatusCode(), e.getMessage()));

--- a/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/recordmatch/AcknowledgmentBuilder.java
+++ b/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/recordmatch/AcknowledgmentBuilder.java
@@ -30,6 +30,9 @@ import org.hl7.fhir.instance.model.MessageHeader.MessageDestinationComponent;
 import org.hl7.fhir.instance.model.MessageHeader.MessageHeaderResponseComponent;
 import org.hl7.fhir.instance.model.MessageHeader.MessageSourceComponent;
 import org.hl7.fhir.instance.model.MessageHeader.ResponseType;
+import org.mitre.ptmatchadapter.util.ResourceSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Constructs a response message that constructs an acknowledgement message for
@@ -39,6 +42,9 @@ import org.hl7.fhir.instance.model.MessageHeader.ResponseType;
  *
  */
 public class AcknowledgmentBuilder {
+  private static final Logger LOG = LoggerFactory
+      .getLogger(AcknowledgmentBuilder.class);
+
 
   private String sourceName = "Unknown";
 
@@ -89,8 +95,13 @@ public class AcknowledgmentBuilder {
     final MessageHeaderResponseComponent resp = new MessageHeaderResponseComponent();
     // This library prefixes identifier w/ 'MessageHeader/', so strip that off
     final String idStr = reqMsgHdr.getId();
-    int pos = idStr.indexOf("/");
-    resp.setIdentifier(idStr.substring(pos + 1));
+    LOG.info("Request Message Header ID: {}", idStr);
+    if (idStr != null) {
+      int pos = idStr.indexOf("/");
+      resp.setIdentifier(idStr.substring(pos + 1));
+    } else {
+      resp.setIdentifier(idStr);
+    }
     resp.setCode(ResponseType.OK);
     msgHdr.setResponse(resp);
 

--- a/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/recordmatch/BasicRecordMatchResultsBuilder.java
+++ b/ptmatchadapter-common/src/main/java/org/mitre/ptmatchadapter/recordmatch/BasicRecordMatchResultsBuilder.java
@@ -150,9 +150,12 @@ public class BasicRecordMatchResultsBuilder {
     final MessageHeaderResponseComponent resp = new MessageHeaderResponseComponent();
     // This library prefixes identifier w/ 'MessageHeader/', so strip that off
     String idStr = reqMsgHdr.getId();
-    int pos = idStr.indexOf("/");
-    if (pos > 0) {
-      idStr = idStr.substring(pos + 1);
+    LOG.info("Request Message Header ID: {}", idStr);
+    if (idStr != null) {
+      final int pos = idStr.indexOf("/");
+      if (pos > 0) {
+        idStr = idStr.substring(pos + 1);
+      }
     }
     resp.setIdentifier(idStr);
     resp.setCode(responseCode);


### PR DESCRIPTION
Update to HAPIR FHIR client to v1.5 required a change to how search is executed.
Add some instructions on building project to README
Add CHANGELOG file in anticipation of forthcoming version.
